### PR TITLE
Updated tests to fit contact-us page

### DIFF
--- a/FJ-about-smoke-spec.js
+++ b/FJ-about-smoke-spec.js
@@ -1,5 +1,6 @@
 describe( 'Beta Contact Page', function() {
-  var baseURL = 'http://beta.consumerfinance.gov/';
+  var passedURL = browser.params.base_url;
+  var baseURL = passedURL ? passedURL : 'http://beta.consumerfinance.gov/';
   var contactURL = baseURL + 'contact-us/';
   var phoneClass = 'list_link__phone';
 
@@ -55,4 +56,3 @@ describe( 'Beta Contact Page', function() {
     expect( lastOffice.getText() ).toMatch( 'Your Money, Your Goals Toolkit' );
   } );
 } );
-

--- a/FJ-about-smoke-spec.js
+++ b/FJ-about-smoke-spec.js
@@ -1,19 +1,58 @@
-describe('The new consumerfinance.gov', function() {
+describe( 'Beta Contact Page', function() {
+  var baseURL = 'http://beta.consumerfinance.gov/';
+  var contactURL = baseURL + 'contact-us/';
+  var phoneClass = 'list_link__phone';
 
-  beforeEach(function() {
+  beforeEach( function() {
     return browser.ignoreSynchronization = true;
-  });
+  } );
 
-  it('should properly load in a browser', function(){
-    browser.get('http://beta.consumerfinance.gov/'); // This could be set to a staging server or localhost.
-    expect(browser.getTitle()).toBe('Consumer Financial Protection Bureau');
-  });
+  it( 'should properly load in a browser', function(){
+    browser.get( contactURL ); // This could be set to a staging server or localhost.
+    expect( browser.getTitle() ).toBe( 'Contact us' );
+  } );
 
-  it('should show the correct phone number', function(){
-    browser.get('http://beta.consumerfinance.gov/contact-us');
-    var phoneNumber = '(855) 411-CFPB (2372)'
-    var phoneElement = element(by.partialLinkText(phoneNumber));
-    expect(phoneElement.getText()).toBeDefined();
-  });
+  it( 'should include the Submit a Complaint phone numbers', function(){
+    var phone = element.all( by.partialLinkText( '(2372)' ) );
+    var firstPhone = phone.first();
+    var secondPhone = phone.last();
 
-});
+    expect( phone.count() ).toEqual( 2 );
+    expect( phone.getAttribute( 'class' ) ).toMatch( phoneClass );
+    expect( firstPhone.getText() ).toBe( '(855) 411-CFPB (2372)' );
+    expect( firstPhone.getAttribute( 'href' ) ).toBe( 'tel:8554112372' )
+    expect( secondPhone.getText() ).toBe( '(855) 729-CFPB (2372) TTY' );
+    expect( secondPhone.getAttribute( 'href' ) ).toBe( 'tel:8557292372' );
+  } );
+
+/* This hasn't been released to beta yet
+  it( 'should link to Submit a Complaint page', function() {
+    var complaintLink = element( by.partialLinkText( 'Submit a complaint' ) );
+
+    expect( complaintLink.getText() ).toBeDefined();
+    expect( complaintLink.getAttribute( 'href' ) ).toMatch( '/complaint/' );
+    expect( complaintLink.getAttribute( 'class' ) ).toMatch( 'jump-link__right' );
+  } );
+*/
+  it( 'should include General Inquiries contact details', function() {
+    var GIEmail = element( by.partialLinkText( 'info@consumerfinance.gov' ) );
+    var GIPhone = element( by.partialLinkText( '(202) 435-7000' ) );
+
+    expect( GIEmail.getText() ).toBeDefined();
+    expect( GIEmail.getAttribute( 'href' ) ).toBe( 'mailto:info@consumerfinance.gov' );
+    expect( GIPhone.getText() ).toBeDefined();
+    expect( GIPhone.getAttribute( 'href' ) ).toBe( 'tel:2024357000' );
+    expect( GIPhone.getAttribute( 'class' ) ).toMatch( phoneClass );
+  } );
+
+  it( 'should include 48 individual offices in alpha order', function() {
+    var offices = element.all( by.css( '.contact-list article' ) );
+    var firstOffice = offices.first().element( by.css( '.expandable_label' ) );
+    var lastOffice = offices.last().element( by.css( '.expandable_label' ) );
+
+    expect( offices.count() ).toEqual( 48 );
+    expect( firstOffice.getText() ).toMatch( 'Academic Research Council' );
+    expect( lastOffice.getText() ).toMatch( 'Your Money, Your Goals Toolkit' );
+  } );
+} );
+


### PR DESCRIPTION
Updated tests to better fit the contact-us page (and set a starting point for more pages to follow)
## Additions
- Added tests for the complaint phone numbers
- Added future tests for the complaint link
- Added tests for the general phone and email
- Added tests for the offices
- Added a base url that is overridable to easily test other staging domains or locally through a `--params.base_url=` flag
## Removals
- Reduced the number of requests to speed up the test (ideally it should be in the beforeEach, but I couldn't get that to work)
## Changes
- None
## Testing
- checkout branch and run `protractor conf.js`
## Review
- @imuchnik 
- @contolini 
- @KimberlyMunoz 
- @anselmbradford 
- @sebworks

[Preview this PR without the whitespace changes](?w=0)
## Notes
- I couldn't get the Page Object stuff working right, hopefully we can figure that out during the call tomorrow
